### PR TITLE
feat: add CLI version using argparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ python secure_pass_gen.py
 
 Follow the on-screen instructions to generate a secure password.
 
+### CLI Version
+
+```bash
+python cli.py
+```
+```
+usage: cli.py [-h] [-l LENGTH] [-r]
+
+options:
+  -h, --help            show this help message and exit
+  -l LENGTH, --length LENGTH
+                        Lenght of the password (Default: 12, Min: 4)
+  -r, --remove-ambiguous
+                        Remove ambiguous characters like 'l', '1', 'O', '0' (Default: False)
+```
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request for improvements, bug fixes, or new features.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,19 @@
+import argparse
+from secure_pass_gen import generate_password
+
+# Create base Parser
+parser = argparse.ArgumentParser()
+
+# Command Optional Arguments
+parser.add_argument('-l', '--length', type=int,default=12, help="Lenght of the password (Default: 12, Min: 4)")
+parser.add_argument('-r', '--remove-ambiguous', action="store_true", default=False, help="Remove ambiguous characters like 'l', '1', 'O', '0' (Default: False)")
+
+# Store argument values
+args = parser.parse_args()
+
+# Generate the password with the specified options
+password, entropy, entropy_level = generate_password(args.length, args.remove_ambiguous)
+
+# Display the generated password and its entropy
+print(f"\nYour new secure password is: {password}")
+print(f"Estimated entropy: {entropy:.2f} bits ({entropy_level})")


### PR DESCRIPTION
This pull request adds CLI capabilities to  Secure-Pass-Generator for a more streamlined workflow using this application in the command line

```bash
❯ py cli.py -h

usage: cli.py [-h] [-l LENGTH] [-r]

options:
  -h, --help            show this help message and exit
  -l LENGTH, --length LENGTH
                        Lenght of the password (Default: 12, Min: 4)
  -r, --remove-ambiguous
                        Remove ambiguous characters like 'l', '1', 'O', '0' (Default: False)
```